### PR TITLE
only exclude top level out file as students will have out files included test-cases

### DIFF
--- a/projects/p1-webpage-cache/.gitignore
+++ b/projects/p1-webpage-cache/.gitignore
@@ -2,4 +2,4 @@
 .project
 togo/
 *.class
-out*
+/out*


### PR DESCRIPTION
Only exclude top level out files in gitignore as students will have out in test-cases.  It is possible to just copy over all the test-cases per grade (if the students edit these) but seems like allowing the out* in test-cases should be fine?